### PR TITLE
Add column visibility state to saved presets

### DIFF
--- a/database/factories/SavedTableFilterFactory.php
+++ b/database/factories/SavedTableFilterFactory.php
@@ -18,6 +18,7 @@ class SavedTableFilterFactory extends Factory
             'resource' => null,
             'name' => fake()->unique()->words(2, true),
             'filters' => [],
+            'columns' => [],
             'is_default' => false,
         ];
     }

--- a/database/migrations/create_filament_table_filter_presets_table.php.stub
+++ b/database/migrations/create_filament_table_filter_presets_table.php.stub
@@ -14,6 +14,7 @@ return new class extends Migration
             $table->string('resource');
             $table->string('name');
             $table->json('filters');
+            $table->json('columns')->nullable();
             $table->boolean('is_default')->default(false);
             $table->timestamps();
 

--- a/resources/lang/en/filters.php
+++ b/resources/lang/en/filters.php
@@ -1,13 +1,13 @@
 <?php
 
 return [
-    'actions' => 'Filter actions',
-    'save' => 'Save Filter',
-    'load' => 'Load Filter',
-    'delete' => 'Delete Filter',
-    'saved_filter' => 'Saved Filter',
+    'actions' => 'Preset actions',
+    'save' => 'Save Preset',
+    'load' => 'Load Preset',
+    'delete' => 'Delete Preset',
+    'saved_filter' => 'Saved Preset',
     'name' => 'Name',
     'set_as_default' => 'Set as default',
-    'filter_saved' => 'Filter saved',
-    'filter_deleted' => 'Filter deleted',
+    'filter_saved' => 'Preset saved',
+    'filter_deleted' => 'Preset deleted',
 ];

--- a/resources/lang/nl/filters.php
+++ b/resources/lang/nl/filters.php
@@ -1,13 +1,13 @@
 <?php
 
 return [
-    'actions' => 'Filteracties',
-    'save' => 'Filter opslaan',
-    'load' => 'Filter laden',
-    'delete' => 'Filter verwijderen',
-    'saved_filter' => 'Opgeslagen filter',
+    'actions' => 'Presetacties',
+    'save' => 'Preset opslaan',
+    'load' => 'Preset laden',
+    'delete' => 'Preset verwijderen',
+    'saved_filter' => 'Opgeslagen preset',
     'name' => 'Naam',
     'set_as_default' => 'Instellen als standaard',
-    'filter_saved' => 'Filter opgeslagen',
-    'filter_deleted' => 'Filter verwijderd',
+    'filter_saved' => 'Preset opgeslagen',
+    'filter_deleted' => 'Preset verwijderd',
 ];

--- a/src/Concerns/HasSavedTableFilters.php
+++ b/src/Concerns/HasSavedTableFilters.php
@@ -19,6 +19,10 @@ trait HasSavedTableFilters
 
         if ($default) {
             $this->tableFilters = $default->filters;
+
+            if ($default->columns) {
+                $this->applyTableColumnManager($default->columns);
+            }
         }
     }
 
@@ -42,13 +46,21 @@ trait HasSavedTableFilters
      * Uses Livewire's SPA navigation for a seamless experience.
      *
      * @param  array<string, mixed>  $filters
+     * @param  array<int, mixed>|null  $columns
      */
-    protected function applySavedFilterState(array $filters): void
+    protected function applySavedFilterState(array $filters, ?array $columns = null): void
     {
         session()->put(
             $this->getTableFiltersSessionKey(),
             $filters,
         );
+
+        if ($columns) {
+            session()->put(
+                $this->getTableColumnsSessionKey(),
+                $columns,
+            );
+        }
 
         $this->redirect(static::getUrl(), navigate: true);
     }
@@ -96,6 +108,7 @@ trait HasSavedTableFilters
                     ],
                     [
                         'filters' => $this->tableFilters ?? [],
+                        'columns' => $this->tableColumns ?? [],
                         'is_default' => $data['is_default'],
                     ],
                 );
@@ -127,7 +140,7 @@ trait HasSavedTableFilters
                     ->first();
 
                 if ($filter) {
-                    $this->applySavedFilterState($filter->filters);
+                    $this->applySavedFilterState($filter->filters, $filter->columns);
                 }
             });
     }

--- a/src/Models/SavedTableFilter.php
+++ b/src/Models/SavedTableFilter.php
@@ -16,6 +16,7 @@ class SavedTableFilter extends Model
         'resource',
         'name',
         'filters',
+        'columns',
         'is_default',
     ];
 
@@ -23,6 +24,7 @@ class SavedTableFilter extends Model
     {
         return [
             'filters' => 'json',
+            'columns' => 'json',
             'is_default' => 'boolean',
         ];
     }

--- a/src/QueryBuilder/Constraints/Operators/TranslatableContainsOperator.php
+++ b/src/QueryBuilder/Constraints/Operators/TranslatableContainsOperator.php
@@ -4,6 +4,7 @@ namespace Wotz\FilamentTableFilterPresets\QueryBuilder\Constraints\Operators;
 
 use Filament\Forms\Components\TextInput;
 use Filament\QueryBuilder\Constraints\TextConstraint\Operators\ContainsOperator;
+use Filament\Schemas\Components\Component;
 use Illuminate\Database\Eloquent\Builder;
 use Wotz\FilamentTableFilterPresets\QueryBuilder\Constraints\Concerns\QueriesTranslatableColumn;
 
@@ -12,7 +13,7 @@ class TranslatableContainsOperator extends ContainsOperator
     use QueriesTranslatableColumn;
 
     /**
-     * @return array<\Filament\Schemas\Components\Component>
+     * @return array<Component>
      */
     public function getFormSchema(): array
     {

--- a/src/QueryBuilder/Constraints/Operators/TranslatableEndsWithOperator.php
+++ b/src/QueryBuilder/Constraints/Operators/TranslatableEndsWithOperator.php
@@ -4,6 +4,7 @@ namespace Wotz\FilamentTableFilterPresets\QueryBuilder\Constraints\Operators;
 
 use Filament\Forms\Components\TextInput;
 use Filament\QueryBuilder\Constraints\TextConstraint\Operators\EndsWithOperator;
+use Filament\Schemas\Components\Component;
 use Illuminate\Database\Eloquent\Builder;
 use Wotz\FilamentTableFilterPresets\QueryBuilder\Constraints\Concerns\QueriesTranslatableColumn;
 
@@ -12,7 +13,7 @@ class TranslatableEndsWithOperator extends EndsWithOperator
     use QueriesTranslatableColumn;
 
     /**
-     * @return array<\Filament\Schemas\Components\Component>
+     * @return array<Component>
      */
     public function getFormSchema(): array
     {

--- a/src/QueryBuilder/Constraints/Operators/TranslatableEqualsOperator.php
+++ b/src/QueryBuilder/Constraints/Operators/TranslatableEqualsOperator.php
@@ -4,6 +4,7 @@ namespace Wotz\FilamentTableFilterPresets\QueryBuilder\Constraints\Operators;
 
 use Filament\Forms\Components\TextInput;
 use Filament\QueryBuilder\Constraints\TextConstraint\Operators\EqualsOperator;
+use Filament\Schemas\Components\Component;
 use Illuminate\Database\Eloquent\Builder;
 use Wotz\FilamentTableFilterPresets\QueryBuilder\Constraints\Concerns\QueriesTranslatableColumn;
 
@@ -12,7 +13,7 @@ class TranslatableEqualsOperator extends EqualsOperator
     use QueriesTranslatableColumn;
 
     /**
-     * @return array<\Filament\Schemas\Components\Component>
+     * @return array<Component>
      */
     public function getFormSchema(): array
     {

--- a/src/QueryBuilder/Constraints/Operators/TranslatableIsTrueOperator.php
+++ b/src/QueryBuilder/Constraints/Operators/TranslatableIsTrueOperator.php
@@ -3,6 +3,7 @@
 namespace Wotz\FilamentTableFilterPresets\QueryBuilder\Constraints\Operators;
 
 use Filament\QueryBuilder\Constraints\BooleanConstraint\Operators\IsTrueOperator;
+use Filament\Schemas\Components\Component;
 use Illuminate\Database\Eloquent\Builder;
 use Wotz\FilamentTableFilterPresets\QueryBuilder\Constraints\Concerns\QueriesTranslatableColumn;
 
@@ -11,7 +12,7 @@ class TranslatableIsTrueOperator extends IsTrueOperator
     use QueriesTranslatableColumn;
 
     /**
-     * @return array<\Filament\Schemas\Components\Component>
+     * @return array<Component>
      */
     public function getFormSchema(): array
     {

--- a/src/QueryBuilder/Constraints/Operators/TranslatableStartsWithOperator.php
+++ b/src/QueryBuilder/Constraints/Operators/TranslatableStartsWithOperator.php
@@ -4,6 +4,7 @@ namespace Wotz\FilamentTableFilterPresets\QueryBuilder\Constraints\Operators;
 
 use Filament\Forms\Components\TextInput;
 use Filament\QueryBuilder\Constraints\TextConstraint\Operators\StartsWithOperator;
+use Filament\Schemas\Components\Component;
 use Illuminate\Database\Eloquent\Builder;
 use Wotz\FilamentTableFilterPresets\QueryBuilder\Constraints\Concerns\QueriesTranslatableColumn;
 
@@ -12,7 +13,7 @@ class TranslatableStartsWithOperator extends StartsWithOperator
     use QueriesTranslatableColumn;
 
     /**
-     * @return array<\Filament\Schemas\Components\Component>
+     * @return array<Component>
      */
     public function getFormSchema(): array
     {

--- a/tests/Feature/SavedTableFilterTest.php
+++ b/tests/Feature/SavedTableFilterTest.php
@@ -2,6 +2,7 @@
 
 use Filament\Facades\Filament;
 use Livewire\Livewire;
+use Workbench\App\Filament\Resources\UserResource;
 use Workbench\App\Filament\Resources\UserResource\Pages\ListUsers;
 use Workbench\App\Models\User;
 use Wotz\FilamentTableFilterPresets\Models\SavedTableFilter;
@@ -46,7 +47,7 @@ it('can save a filter preset as default', function () {
 it('clears previous default when saving a new default filter', function () {
     $existing = SavedTableFilter::factory()->default()->create([
         'administrator_id' => $this->admin->id,
-        'resource' => \Workbench\App\Filament\Resources\UserResource::class,
+        'resource' => UserResource::class,
     ]);
 
     Livewire::test(ListUsers::class)
@@ -69,7 +70,7 @@ it('can load a saved filter preset', function () {
 
     $savedFilter = SavedTableFilter::factory()->create([
         'administrator_id' => $this->admin->id,
-        'resource' => \Workbench\App\Filament\Resources\UserResource::class,
+        'resource' => UserResource::class,
         'filters' => $filterState,
     ]);
 
@@ -83,7 +84,7 @@ it('can load a saved filter preset', function () {
 it('can delete a saved filter preset', function () {
     $savedFilter = SavedTableFilter::factory()->create([
         'administrator_id' => $this->admin->id,
-        'resource' => \Workbench\App\Filament\Resources\UserResource::class,
+        'resource' => UserResource::class,
     ]);
 
     Livewire::test(ListUsers::class)
@@ -100,7 +101,7 @@ it('can delete a saved filter preset', function () {
 it('auto-applies default filter on mount', function () {
     SavedTableFilter::factory()->default()->create([
         'administrator_id' => $this->admin->id,
-        'resource' => \Workbench\App\Filament\Resources\UserResource::class,
+        'resource' => UserResource::class,
         'filters' => ['status' => ['value' => 'active']],
     ]);
 
@@ -118,7 +119,7 @@ it('scopes filters per user', function () {
     SavedTableFilter::factory()->create([
         'administrator_id' => $otherUser->id,
         'name' => 'Other User Filter',
-        'resource' => \Workbench\App\Filament\Resources\UserResource::class,
+        'resource' => UserResource::class,
     ]);
 
     $currentUserFilters = SavedTableFilter::query()
@@ -133,7 +134,7 @@ it('enforces unique constraint on name per user and resource', function () {
     SavedTableFilter::factory()->create([
         'administrator_id' => $this->admin->id,
         'name' => 'Duplicate Name',
-        'resource' => \Workbench\App\Filament\Resources\UserResource::class,
+        'resource' => UserResource::class,
     ]);
 
     Livewire::test(ListUsers::class)
@@ -153,7 +154,7 @@ it('enforces unique constraint on name per user and resource', function () {
 it('belongs to an administrator', function () {
     $savedFilter = SavedTableFilter::factory()->create([
         'administrator_id' => $this->admin->id,
-        'resource' => \Workbench\App\Filament\Resources\UserResource::class,
+        'resource' => UserResource::class,
     ]);
 
     expect($savedFilter->administrator)

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -17,6 +17,7 @@ use Illuminate\Database\Eloquent\Factories\Factory;
 use Livewire\LivewireServiceProvider;
 use Orchestra\Testbench\TestCase as Orchestra;
 use RyanChandler\BladeCaptureDirective\BladeCaptureDirectiveServiceProvider;
+use Workbench\App\Models\User;
 use Workbench\App\Providers\Filament\AdminPanelProvider;
 use Wotz\FilamentTableFilterPresets\FilamentTableFilterPresetsServiceProvider;
 use Wotz\LocaleCollection\Providers\LocaleCollectionServiceProvider;
@@ -64,8 +65,8 @@ class TestCase extends Orchestra
         config()->set('database.default', 'testing');
         config()->set('cache.default', 'array');
         config()->set('session.driver', 'array');
-        config()->set('filament-table-filter-presets.administrator_model', \Workbench\App\Models\User::class);
-        config()->set('auth.providers.users.model', \Workbench\App\Models\User::class);
+        config()->set('filament-table-filter-presets.administrator_model', User::class);
+        config()->set('auth.providers.users.model', User::class);
 
         $app['db']->connection()->getSchemaBuilder()->create('users', function ($table) {
             $table->id();

--- a/workbench/app/Filament/Resources/UserResource.php
+++ b/workbench/app/Filament/Resources/UserResource.php
@@ -5,6 +5,7 @@ namespace Workbench\App\Filament\Resources;
 use Filament\Resources\Resource;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
+use Workbench\App\Filament\Resources\UserResource\Pages\ListUsers;
 use Workbench\App\Models\User;
 
 class UserResource extends Resource
@@ -23,7 +24,7 @@ class UserResource extends Resource
     public static function getPages(): array
     {
         return [
-            'index' => \Workbench\App\Filament\Resources\UserResource\Pages\ListUsers::route('/'),
+            'index' => ListUsers::route('/'),
         ];
     }
 }

--- a/workbench/app/Models/User.php
+++ b/workbench/app/Models/User.php
@@ -4,6 +4,7 @@ namespace Workbench\App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
+use Workbench\Database\Factories\UserFactory;
 
 class User extends Authenticatable
 {
@@ -25,8 +26,8 @@ class User extends Authenticatable
         ];
     }
 
-    protected static function newFactory(): \Workbench\Database\Factories\UserFactory
+    protected static function newFactory(): UserFactory
     {
-        return \Workbench\Database\Factories\UserFactory::new();
+        return UserFactory::new();
     }
 }


### PR DESCRIPTION
Save and restore table column toggle/visibility state alongside                                      
filters, so a single preset captures both what data is filtered and which columns are shown.

- Add nullable `columns` JSON column to migration stub
- Store `tableColumns` state when saving a preset
- Restore column state via `applyTableColumnManager()` on load
- Persist columns to session in `applySavedFilterState()`
- Rename "Filter" to "Preset" in EN/NL translations
